### PR TITLE
move the magic strings away

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,6 +79,7 @@ dependencies = [
  "ed25519-dalek",
  "failure",
  "hex",
+ "lazy_static",
  "pbp",
  "rand 0.8.5",
  "serde",
@@ -301,6 +302,12 @@ name = "hex"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"

--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@ I do.
 
 ## How to Install
 
+> [!Note]
+> This tool is not yet available on `crates.io`. You can install it from source
+> below. To change the default keychain service, you can define `BPB_SERVICE_NAME`
+> in your environment at build time.
+
 ```sh
 git clone https://github.com/pkgxdev/bpb
 cd bpb
@@ -102,11 +107,6 @@ delegates to the gpg binary in your path.
 This means that this program can be used to replace gpg as a signing tool, but
 it does not replace any other functionality. For example, if you want to
 verify the signatures on other peoples' git commits, it will shell out to gpg.
-
-
-## TODO
-
-- [ ] Move keychain identifiers out to build variables in `main.rs`
 
 
 [teaBASE]: https://github.com/teaxyz/teaBASE

--- a/bpb/Cargo.toml
+++ b/bpb/Cargo.toml
@@ -15,6 +15,7 @@ serde_derive = "1.0.215"
 serde = "1.0.215"
 hex = "0.3.2"
 failure = "0.1.1"
+lazy_static = "1.5.0"
 
 [dependencies.pbp]
 path = "../pbp"

--- a/bpb/src/config.rs
+++ b/bpb/src/config.rs
@@ -1,6 +1,13 @@
 use std::io::{Read, Write};
 
 use failure::Error;
+use lazy_static::lazy_static;
+
+lazy_static! {
+    static ref SERVICE_NAME: String = option_env!("BPB_SERVICE_NAME")
+        .unwrap_or("xyz.tea.BASE.bpb")
+        .to_string();
+}
 
 #[derive(Serialize, Deserialize)]
 pub struct Config {
@@ -40,6 +47,10 @@ impl Config {
 
     pub fn user_id(&self) -> &str {
         &self.public.userid
+    }
+
+    pub fn service(&self) -> &str {
+        &SERVICE_NAME
     }
 }
 

--- a/bpb/src/main.rs
+++ b/bpb/src/main.rs
@@ -62,7 +62,8 @@ fn generate_keypair(userid: String) -> Result<(), Error> {
     if let Ok(_config) = Config::load() {
         eprintln!(
             "A keypair already exists. If you (really) want to reinitialize your state\n\
-                   run `security delete-generic-password -s xyz.tea.BASE.bpb` first."
+                   run `security delete-generic-password -s {}` first.",
+            _config.service()
         );
         return Ok(());
     }
@@ -79,7 +80,7 @@ fn generate_keypair(userid: String) -> Result<(), Error> {
     let config = Config::create(public_key, userid, timestamp)?;
     config.write()?;
 
-    let service = "xyz.tea.BASE.bpb";
+    let service = config.service();
     let account = config.user_id();
     let hex = hex::encode(keypair.to_bytes());
     add_keychain_item(service, account, &hex)?;
@@ -92,7 +93,7 @@ fn generate_keypair(userid: String) -> Result<(), Error> {
 
 fn print_public_key() -> Result<(), Error> {
     let config = Config::load()?;
-    let service = "xyz.tea.BASE.bpb";
+    let service = config.service();
     let account = config.user_id();
     let secret_str = get_keychain_item(service, account)?;
     let secret = to_32_bytes(&secret_str)?;
@@ -110,7 +111,7 @@ fn verify_commit() -> Result<(), Error> {
     stdin.read_to_string(&mut commit)?;
 
     let config = Config::load()?;
-    let service = "xyz.tea.BASE.bpb";
+    let service = config.service();
     let account = config.user_id();
     let secret_str = get_keychain_item(service, account)?;
     let secret = to_32_bytes(&secret_str)?;
@@ -137,7 +138,7 @@ fn delegate() -> ! {
 fn upgrade() -> Result<(), Error> {
     let mut file = std::fs::File::open(legacy_keys_file())?;
     let (config, secret) = LegacyConfig::convert(&mut file)?;
-    let service = "xyz.tea.BASE.bpb";
+    let service = config.service();
     let account = config.user_id();
     let hex = hex::encode(secret);
     add_keychain_item(service, account, &hex)?;


### PR DESCRIPTION
we should consider just passing a `&Config` to our keychain functions for simplicity. Or make them implementations on the `Config` instance, more likely.
