### PR TITLE
Add `fingerprint` and `key-id` commands

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -87,7 +87,7 @@ jobs:
           toolchain: 1.81.0
           override: true
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         env:
           cache-name: cache-dependencies
         with:

--- a/bpb/src/config.rs
+++ b/bpb/src/config.rs
@@ -62,25 +62,22 @@ struct PublicKey {
 }
 
 fn keys_file() -> std::path::PathBuf {
-  // for archaic reasons we first check the config path
-  // however this is an error, we shouldn’t store this as config seeing as it is
-  // tied to the private key which is likely a host setting and should not thus be
-  // synced between machines
+    // for archaic reasons we first check the config path
+    // however this is an error, we shouldn’t store this as config seeing as it is
+    // tied to the private key which is likely a host setting and should not thus be
+    // synced between machines
 
-  let config_path = if let Ok(config_home) = std::env::var("XDG_CONFIG_HOME") {
-      std::path::PathBuf::from(config_home).join("pkgx/bpb.toml")
-  } else {
-      std::path::PathBuf::from(std::env::var("HOME").unwrap()).join(".config/pkgx/bpb.toml")
-  };
+    let config_path = if let Ok(config_home) = std::env::var("XDG_CONFIG_HOME") {
+        std::path::PathBuf::from(config_home).join("pkgx/bpb.toml")
+    } else {
+        std::path::PathBuf::from(std::env::var("HOME").unwrap()).join(".config/pkgx/bpb.toml")
+    };
 
-  if config_path.exists() {
-      config_path
-  } else {
-      let data_path = if let Ok(data_home) = std::env::var("XDG_DATA_HOME") {
-          std::path::PathBuf::from(data_home).join("pkgx/bpb.toml")
-      } else {
-          std::path::PathBuf::from(std::env::var("HOME").unwrap()).join(".local/share/pkgx/bpb.toml")
-      };
-      data_path
-  }
+    if config_path.exists() {
+        config_path
+    } else if let Ok(data_home) = std::env::var("XDG_DATA_HOME") {
+        std::path::PathBuf::from(data_home).join("pkgx/bpb.toml")
+    } else {
+        std::path::PathBuf::from(std::env::var("HOME").unwrap()).join(".local/share/pkgx/bpb.toml")
+    }
 }

--- a/bpb/src/keychain.rs
+++ b/bpb/src/keychain.rs
@@ -81,8 +81,7 @@ pub fn add_keychain_item(service: &str, account: &str, secret: &str) -> Result<(
             Ok(())
         } else {
             Err(failure::err_msg(format!(
-                "SecItemAdd failed with status: {}",
-                status
+                "SecItemAdd failed with status: {status}"
             )))
         }
     }
@@ -155,8 +154,7 @@ pub fn get_keychain_item(service: &str, account: &str) -> Result<String, Error> 
             Ok(secret)
         } else {
             Err(failure::err_msg(format!(
-                "SecItemCopyMatching failed with status: {}",
-                status
+                "SecItemCopyMatching failed with status: {status}"
             )))
         }
     }

--- a/bpb/src/main.rs
+++ b/bpb/src/main.rs
@@ -123,7 +123,7 @@ fn verify_commit() -> Result<(), Error> {
     let sig = keypair.sign(commit.as_bytes())?;
 
     eprintln!("\n[GNUPG:] SIG_CREATED ");
-    println!("{}", sig);
+    println!("{sig}");
     Ok(())
 }
 


### PR DESCRIPTION
cleans up some lints and formatting issues as well.